### PR TITLE
Chapter 11 Exercise

### DIFF
--- a/lib/heads_up_web/live/effort_live.ex
+++ b/lib/heads_up_web/live/effort_live.ex
@@ -25,12 +25,27 @@ defmodule HeadsUpWeb.EffortLive do
           {@responders * @minutes_per_responder} Minutes
         </div>
       </section>
+
+      <form phx-submit="set-minutes-per-responder">
+        <label>Minutes Per Responder:</label>
+        <input type="number" name="minutes_per_responder" value={@minutes_per_responder} min="1" />
+      </form>
     </div>
     """
   end
 
   def handle_event("add", %{"quantity" => quantity}, socket) do
     socket = update(socket, :responders, &(&1 + String.to_integer(quantity)))
+
+    {:noreply, socket}
+  end
+
+  def handle_event(
+        "set-minutes-per-responder",
+        %{"minutes_per_responder" => minutes_per_responder},
+        socket
+      ) do
+    socket = assign(socket, :minutes_per_responder, String.to_integer(minutes_per_responder))
 
     {:noreply, socket}
   end


### PR DESCRIPTION
[chp11]
_this PR does the following_
* adds a new form that lets you set the minutes_per_responder variable
* unasked for in the exercise but I also decided to update the UI to tell the number of hours and minutes depending on the total number of minutes
### Exercise
Basically a copy of what we did for Raffley in chapter 11 as well, can be seen here: [Commit](https://github.com/notdevinclark/raffley/commit/79d382640695d34c7b92484347d5eb1c631c1b74). I ended up also trying to have a bit more fun and updated the UI to show hours and minutes depending on the total of minutes, so, 59 minutes shows 59 minutes, but 61 minutes show 1 Hour and 1 Minute, that change has been encapsulated into a commit so if the next changes cause a huge change or refactor, I can easily remove that change from the commit stack.