### PR TITLE
Chapter 18 Exercise

### DIFF
--- a/lib/heads_up/incidents.ex
+++ b/lib/heads_up/incidents.ex
@@ -33,4 +33,21 @@ defmodule HeadsUp.Incidents do
       }
     ]
   end
+
+  def get_incident(id) when is_binary(id) do
+    id
+    |> String.to_integer()
+    |> get_incident()
+  end
+
+  def get_incident(id) when is_integer(id) do
+    list_incidents()
+    |> Enum.find(fn incident ->
+      incident.id == id
+    end)
+  end
+
+  def urgent_incidents(incident) do
+    list_incidents() |> List.delete(incident)
+  end
 end

--- a/lib/heads_up/tips.ex
+++ b/lib/heads_up/tips.ex
@@ -29,6 +29,7 @@ defmodule HeadsUp.Tips do
     |> String.to_integer()
     |> get_tip()
   end
+
   def get_tip(id) when is_integer(id) do
     list_tips()
     |> Enum.find(fn tip ->

--- a/lib/heads_up_web/components/layouts/root.html.heex
+++ b/lib/heads_up_web/components/layouts/root.html.heex
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="csrf-token" content={get_csrf_token()} />
-    <.live_title>
+    <.live_title suffix=" · HeadsUp">
       {assigns[:page_title] || "HeadsUp"}
     </.live_title>
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />

--- a/lib/heads_up_web/controllers/tip_controller.ex
+++ b/lib/heads_up_web/controllers/tip_controller.ex
@@ -11,12 +11,12 @@ defmodule HeadsUpWeb.TipController do
 
     tips = Tips.list_tips()
 
-    render(conn, :index, %{emojis: emojis, tips: tips})
+    render(conn, :index, %{emojis: emojis, tips: tips, page_title: "Tips"})
   end
 
   def show(conn, %{"id" => id}) do
     tip = Tips.get_tip(id)
 
-    render(conn, :show, tip: tip)
+    render(conn, :show, tip: tip, page_title: "Tip #{id}")
   end
 end

--- a/lib/heads_up_web/live/incident_live/index.ex
+++ b/lib/heads_up_web/live/incident_live/index.ex
@@ -5,7 +5,7 @@ defmodule HeadsUpWeb.IncidentLive.Index do
   import HeadsUpWeb.CustomComponents
 
   def mount(_params, _session, socket) do
-    socket = assign(socket, :incidents, Incidents.list_incidents())
+    socket = assign(socket, incidents: Incidents.list_incidents(), page_title: "Incidents")
     {:ok, socket}
   end
 

--- a/lib/heads_up_web/live/incident_live/show.ex
+++ b/lib/heads_up_web/live/incident_live/show.ex
@@ -1,0 +1,63 @@
+defmodule HeadsUpWeb.IncidentLive.Show do
+  use HeadsUpWeb, :live_view
+
+  alias HeadsUp.Incidents
+  import HeadsUpWeb.CustomComponents
+
+  def mount(_params, _session, socket) do
+    {:ok, socket}
+  end
+
+  def handle_params(%{"id" => id}, _uri, socket) do
+    incident = Incidents.get_incident(id)
+
+    socket =
+      socket
+      |> assign(:incident, incident)
+      |> assign(:page_title, incident.name)
+      |> assign(:urgent_incidents, Incidents.urgent_incidents(incident))
+
+    {:noreply, socket}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div class="incident-show">
+      <div class="incident">
+        <img src={@incident.image_path} />
+        <section>
+          <.badge status={@incident.status} />
+          <header>
+            <h2>{@incident.name}</h2>
+            <div class="priority">
+              {@incident.priority}
+            </div>
+          </header>
+          <div class="description">
+            {@incident.description}
+          </div>
+        </section>
+      </div>
+      <div class="activity">
+        <div class="left"></div>
+        <div class="right">
+          <.urgent_incidents incidents={@urgent_incidents} />
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  def urgent_incidents(assigns) do
+    ~H"""
+    <section>
+      <h4>Urgent Incidents</h4>
+      <ul :for={incident <- @incidents} class="incidents">
+        <li>
+          <img src={incident.image_path} /> {incident.name}
+        </li>
+      </ul>
+    </section>
+    """
+  end
+end

--- a/lib/heads_up_web/router.ex
+++ b/lib/heads_up_web/router.ex
@@ -23,6 +23,7 @@ defmodule HeadsUpWeb.Router do
     get "/tips/:id", TipController, :show
     live "/effort", EffortLive
     live "/incidents", IncidentLive.Index
+    live "/incidents/:id", IncidentLive.Show
   end
 
   # Other scopes may use custom stacks.


### PR DESCRIPTION
[chp18]
_this PR does the following_
* create a new show live_view for incidents
* add a way to get a specific incident
* add a way to get all other urgent incidents
* update ui so that we can display it all from the new show live_view
* update all other views that have missing page_titles and make sure they have them properly showing
### Exercise
All of the work we did in Raffley for chapter 18 we repeated here, can be seen here: [Commit](https://github.com/notdevinclark/raffley/commit/d953ff0c21aeae63d12b0d29fbf1e86f778fae4f). I also cleaned up and updated all the views we have that had missing page_titles.