### PR TITLE
Chapter 21 Exercise

### DIFF
--- a/.iex.exs
+++ b/.iex.exs
@@ -1,0 +1,3 @@
+alias HeadsUp.Repo
+alias HeadsUp.Incidents
+alias HeadsUp.Incidents.Incident

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  local-postgres-service:
+    container_name: local-postgresql
+    image: postgres:16.2-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
+    volumes:
+      - local-postgres-volume:/var/lib/postgresql/data
+    networks:
+      - local-postgres-network
+
+volumes:
+  local-postgres-volume:
+
+networks:
+  local-postgres-network:

--- a/lib/heads_up/incidents.ex
+++ b/lib/heads_up/incidents.ex
@@ -1,46 +1,13 @@
 defmodule HeadsUp.Incidents do
+  alias HeadsUp.Repo
   alias HeadsUp.Incidents.Incident
 
   def list_incidents do
-    [
-      %Incident{
-        id: 1,
-        name: "Lost Dog",
-        description: "A friendly dog is wandering around the neighborhood. 🐶",
-        priority: 2,
-        status: :pending,
-        image_path: "/images/lost-dog.jpg"
-      },
-      %Incident{
-        id: 2,
-        name: "Flat Tire",
-        description: "Our beloved ice cream truck has a flat tire! 🛞",
-        priority: 1,
-        status: :resolved,
-        image_path: "/images/flat-tire.jpg"
-      },
-      %Incident{
-        id: 3,
-        name: "Bear In The Trash",
-        description: "A curious bear is digging through the trash! 🐻",
-        priority: 1,
-        status: :canceled,
-        image_path: "/images/bear-in-trash.jpg"
-      }
-    ]
+    Repo.all(Incident)
   end
 
-  def get_incident(id) when is_binary(id) do
-    id
-    |> String.to_integer()
-    |> get_incident()
-  end
-
-  def get_incident(id) when is_integer(id) do
-    list_incidents()
-    |> Enum.find(fn incident ->
-      incident.id == id
-    end)
+  def get_incident!(id) do
+    Repo.get(Incident, id)
   end
 
   def urgent_incidents(incident) do

--- a/lib/heads_up_web/live/incident_live/show.ex
+++ b/lib/heads_up_web/live/incident_live/show.ex
@@ -9,7 +9,7 @@ defmodule HeadsUpWeb.IncidentLive.Show do
   end
 
   def handle_params(%{"id" => id}, _uri, socket) do
-    incident = Incidents.get_incident(id)
+    incident = Incidents.get_incident!(id)
 
     socket =
       socket

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -9,3 +9,138 @@
 #
 # We recommend using the bang functions (`insert!`, `update!`
 # and so on) as they will fail if something goes wrong.
+
+alias HeadsUp.Repo
+alias HeadsUp.Incidents.Incident
+
+%Incident{
+  name: "Lost Dog",
+  description: """
+  A friendly dog is wandering around the neighborhood, looking a bit confused and out of place. He seems to have lost his way and could really use a little help finding his way back home! 🐶
+  """,
+  priority: 2,
+  status: :pending,
+  image_path: "/images/lost-dog.jpg"
+}
+|> Repo.insert!()
+
+%Incident{
+  name: "Tree Down On Roadway",
+  description: """
+  A hefty tree toppled over and is now lounging across the road! We need some extra hands to move this leafy roadblock and get things moving again. 🌲
+  """,
+  priority: 1,
+  status: :canceled,
+  image_path: "/images/tree-down.jpg"
+}
+|> Repo.insert!()
+
+%Incident{
+  name: "Snowplow Stuck",
+  description: """
+  Looks like our trusty snowplow got a little too cozy with the snow and is now stuck! If you've got some muscle and a shovel, we could use a hand to set it free! ❄️
+  """,
+  priority: 2,
+  status: :pending,
+  image_path: "/images/snowplow-stuck.jpg"
+}
+|> Repo.insert!()
+
+%Incident{
+  name: "Website Down",
+  description: """
+  Yikes! The community website has taken an unscheduled nap and needs a little TLC to get back online. If you can lend a tech-savvy hand, we'd really appreciate the assist! 🔥
+  """,
+  priority: 2,
+  status: :resolved,
+  image_path: "/images/website-down.jpg"
+}
+|> Repo.insert!()
+
+%Incident{
+  name: "Bear In The Trash",
+  description: """
+  A curious bear is digging through the trash, like it's his own personal buffet. He's making quite the mess but looks too pleased with his scavenger hunt to care! 🐻
+  """,
+  priority: 1,
+  status: :canceled,
+  image_path: "/images/bear-in-trash.jpg"
+}
+|> Repo.insert!()
+
+%Incident{
+  name: "Overactive Pumpkin Patch",
+  description: """
+  Our pumpkin patch went into overdrive and now we've got pumpkins galore! Come on over and grab a few. Let's share the pumpkin love with the whole community! 🎃
+  """,
+  priority: 2,
+  status: :resolved,
+  image_path: "/images/pumpkin-patch.jpg"
+}
+|> Repo.insert!()
+
+%Incident{
+  name: "Moose On The Loose",
+  description: """
+  A big ol' moose is on the loose, wandering through the neighborhood like he owns the place. He's turning heads and causing quite a stir, probably just looking for a snack or some new scenery! 🫎
+  """,
+  priority: 3,
+  status: :pending,
+  image_path: "/images/moose-on-loose.jpg"
+}
+|> Repo.insert!()
+
+%Incident{
+  name: "Flat Tire",
+  description: """
+  Uh-oh! Our beloved ice cream truck has a flat tire and needs a helping hand to get back on the road. The treats are melting, and we need some quick assistance to save the day! 🛞
+  """,
+  priority: 1,
+  status: :resolved,
+  image_path: "/images/flat-tire.jpg"
+}
+|> Repo.insert!()
+
+%Incident{
+  name: "Cat Stuck In Tree",
+  description: """
+  A mischievous cat is stuck high in a tree, meowing loudly for some assistance. He's realizing that his grand adventure up the branches might need a little human intervention to get back down! 🙀
+  """,
+  priority: 3,
+  status: :resolved,
+  image_path: "/images/cat-in-tree.jpg"
+}
+|> Repo.insert!()
+
+%Incident{
+  name: "Annoying Drone",
+  description: """
+  There's an obnoxious drone buzzing around like an over-caffeinated mosquito. It's causing quite a ruckus and making everyone look up and groan! 🛸
+  """,
+  priority: 3,
+  status: :pending,
+  image_path: "/images/annoying-drone.jpg"
+}
+|> Repo.insert!()
+
+%Incident{
+  name: "Washed-Out Trail",
+  description: """
+  The heavy rains have turned our favorite hiking trail into a muddy mess! A little repair work will have it back in hiking shape in no time. 💦
+  """,
+  priority: 3,
+  status: :pending,
+  image_path: "/images/washed-out-trail.jpg"
+}
+|> Repo.insert!()
+
+%Incident{
+  name: "Suspicious Vehicle",
+  description: """
+  There's a clownish vehicle cruising around, looking like it rolled straight out of a circus. It's raising a few eyebrows, so maybe it's time for a friendly check to see what's up! 🤡
+  """,
+  priority: 3,
+  status: :canceled,
+  image_path: "/images/suspicious-vehicle.jpg"
+}
+|> Repo.insert!()


### PR DESCRIPTION
[chp21]
_this PR does the following_
* adds a docker-compose.yml for handling quick postgres access for development
* expands iex defaults for access incidents and repo modules
* updates the incident modules so that we can now properly use the Repo module to get data from the db
### Exercise
Basically what we did in Raffley for Chapter 21, seen here: [Commit](https://github.com/notdevinclark/raffley/commit/fd5dce11dcb63da7469a71abcd2b60ba095aa833). I also added a docker-compose.yml that will handle starting up a default postgresql image with the proper db access rights so I can get started with any new elixir/phoenix project.

I also made said [docker-compose.yml available as a public gist](https://gist.github.com/notdevinclark/44689e8b225c80c4a1646bd1d08d9408) for all to use.