### PR TITLE
Chapter 22 Exercise

### DIFF
--- a/lib/heads_up_web/live/incident_live/index.ex
+++ b/lib/heads_up_web/live/incident_live/index.ex
@@ -5,7 +5,18 @@ defmodule HeadsUpWeb.IncidentLive.Index do
   import HeadsUpWeb.CustomComponents
 
   def mount(_params, _session, socket) do
-    socket = assign(socket, incidents: Incidents.list_incidents(), page_title: "Incidents")
+    socket =
+      socket
+      |> stream(:incidents, Incidents.list_incidents())
+      |> assign(:page_title, "Incidents")
+
+    # socket =
+    #   attach_hook(socket, :log_stream, :after_render, fn
+    #     socket ->
+    #       # inspect the stream
+    #       socket
+    #   end)
+
     {:ok, socket}
   end
 
@@ -22,18 +33,23 @@ defmodule HeadsUpWeb.IncidentLive.Index do
         </:taglines>
       </.headline>
 
-      <div class="incidents">
-        <.incident_card :for={incident <- @incidents} incident={incident} />
+      <div class="incidents" id="incidents" phx-stream="stream">
+        <.incident_card
+          :for={{dom_id, incident} <- @streams.incidents}
+          incident={incident}
+          id={dom_id}
+        />
       </div>
     </div>
     """
   end
 
   attr :incident, HeadsUp.Incidents.Incident, required: true
+  attr :id, :string, required: true
 
   def incident_card(assigns) do
     ~H"""
-    <.link navigate={~p"/incidents/#{@incident}"}>
+    <.link navigate={~p"/incidents/#{@incident}"} id={@id}>
       <div class="card">
         <img src={@incident.image_path} />
         <h2>{@incident.name}</h2>


### PR DESCRIPTION
[chp22]
_this PR does the following_
* updates the incidents index to use streams instead of assign for the list of incidents
### Exercise
Same thing we did in Raffley for chapters 22, seen here: [Commit](https://github.com/notdevinclark/raffley/commit/c9955578307d6989ebb3c8142444bc705b3fb6d9). Could not think of anything new to add, I could rewrite the data stream for tips and move them to do the db which I think about doing in my spare time. 